### PR TITLE
FSProvider: don't parse resource version

### DIFF
--- a/src/FSProvider.ts
+++ b/src/FSProvider.ts
@@ -43,8 +43,8 @@ export class FSProvider implements vscode.FileSystemProvider {
 
     let ctimeIso = obj.metadata?.creationTimestamp;
     let ctime = ctimeIso ? new Date(ctimeIso).getTime() : 0;
-    let resourceVersion = obj.metadata?.resourceVersion;
-    let mtime = resourceVersion ? ctime + parseInt(resourceVersion) : new Date().getTime();
+    let generation = obj.metadata?.generation;
+    let mtime = generation ? ctime + generation : new Date().getTime();
 
     return {
         type: vscode.FileType.File,


### PR DESCRIPTION
Parsing the resourceVersion as an integer is strictly prohibited by the Kubernetes API [1]. During a review of code that would be affected by non-numerical resourceVersions, I came upon this code. It looks like this code is using the resourceVersion as a change detection mechanism to determine a modification timestamp - the generation field in metadata can be used for this purpose instead. While this field won't capture all changes to the object, perhaps it is sufficient.

[1] https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>